### PR TITLE
Allow base loading of previews.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "suggest": {
-        "livewire/livewire": "If you don't have any livewire components, this package will be very boring...",
+        "livewire/livewire": "If you don't have any livewire components, this package will be very boring..."
     },
     "require": {
         "php": "^8.3",

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
     "autoload": {
         "psr-4": {
             "Allenjd3\\WireLook\\": "src/",
-            "Allenjd3\\WireLook\\Database\\Factories\\": "database/factories/",
+            "Allenjd3\\WireLook\\Database\\Factories\\": "database/factories/"
         }
     },
     "autoload-dev": {

--- a/composer.json
+++ b/composer.json
@@ -15,15 +15,19 @@
             "role": "Developer"
         }
     ],
+    "suggest": {
+        "livewire/livewire": "If you don't have any livewire components, this package will be very boring...",
+    },
     "require": {
         "php": "^8.3",
         "spatie/laravel-package-tools": "^1.16",
         "illuminate/contracts": "^10.0||^11.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.14",
-        "nunomaduro/collision": "^8.1.1||^7.10.0",
         "larastan/larastan": "^2.9",
+        "laravel/pint": "^1.14",
+        "livewire/livewire": "^3.5",
+        "nunomaduro/collision": "^8.1.1||^7.10.0",
         "orchestra/testbench": "^9.0.0||^8.22.0",
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-arch": "^3.0",
@@ -36,7 +40,7 @@
     "autoload": {
         "psr-4": {
             "Allenjd3\\WireLook\\": "src/",
-            "Allenjd3\\WireLook\\Database\\Factories\\": "database/factories/"
+            "Allenjd3\\WireLook\\Database\\Factories\\": "database/factories/",
         }
     },
     "autoload-dev": {

--- a/config/wirelook.php
+++ b/config/wirelook.php
@@ -2,5 +2,6 @@
 
 // config for Allenjd3/WireLook
 return [
-
+    'preview_path' => env('WIRELOOK_PREVIEW_PATH', app_path('Previews')),
+    'preview_namespace' => env('WIRELOOK_PREVIEW_NAMESPACE', 'App\Previews'),
 ];

--- a/config/wirelook.php
+++ b/config/wirelook.php
@@ -2,6 +2,6 @@
 
 // config for Allenjd3/WireLook
 return [
-    'preview_path' => env('WIRELOOK_PREVIEW_PATH', app_path('Previews') . '/'),
+    'preview_path' => env('WIRELOOK_PREVIEW_PATH', app_path('Previews').'/'),
     'preview_namespace' => env('WIRELOOK_PREVIEW_NAMESPACE', 'App\\Previews\\'),
 ];

--- a/config/wirelook.php
+++ b/config/wirelook.php
@@ -2,6 +2,6 @@
 
 // config for Allenjd3/WireLook
 return [
-    'preview_path' => env('WIRELOOK_PREVIEW_PATH', app_path('Previews')),
-    'preview_namespace' => env('WIRELOOK_PREVIEW_NAMESPACE', 'App\Previews'),
+    'preview_path' => env('WIRELOOK_PREVIEW_PATH', app_path('Previews') . '/'),
+    'preview_namespace' => env('WIRELOOK_PREVIEW_NAMESPACE', 'App\\Previews\\'),
 ];

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,0 +1,3 @@
+<div>
+Hello World!
+</div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,8 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title></title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+</head>
+<body>
 <div>
     @livewireStyles
         @foreach($keys as $key)
             <div>
-                <a href="{{ route('wirelook', ['componentName' => $key]) }}">{{ $key }}</a>
+                <a href="{{ route('wirelook', ['component' => $key]) }}">{{ $key }}</a>
             </div>
         @endforeach
         @if (isset($componentName))
@@ -10,3 +18,5 @@
         @endif
     @livewireScripts
 </div>
+</body>
+</html>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,3 +1,6 @@
 <div>
-Hello World!
+    @livewireStyles
+        Hello World!
+        @livewire('wirelook::base-component')
+    @livewireScripts
 </div>

--- a/resources/views/index.blade.php
+++ b/resources/views/index.blade.php
@@ -1,6 +1,12 @@
 <div>
     @livewireStyles
-        Hello World!
-        @livewire('wirelook::base-component')
+        @foreach($keys as $key)
+            <div>
+                <a href="{{ route('wirelook', ['componentName' => $key]) }}">{{ $key }}</a>
+            </div>
+        @endforeach
+        @if (isset($componentName))
+            @livewire($componentName)
+        @endif
     @livewireScripts
 </div>

--- a/resources/views/livewire/base.blade.php
+++ b/resources/views/livewire/base.blade.php
@@ -1,0 +1,1 @@
+<div>hello</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,4 +5,3 @@ use Allenjd3\WireLook\Middleware\LocalOnly;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/wirelook', WireLookController::class)->middleware(LocalOnly::class)->name('wirelook');
-

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,0 +1,7 @@
+<?php
+
+use Allenjd3\WireLook\Middleware\LocalOnly;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/wirelook', fn() => 'hello world')->middleware(LocalOnly::class);
+

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,7 +1,8 @@
 <?php
 
+use Allenjd3\WireLook\Controllers\WireLookController;
 use Allenjd3\WireLook\Middleware\LocalOnly;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/wirelook', fn() => 'hello world')->middleware(LocalOnly::class);
+Route::get('/wirelook', WireLookController::class)->middleware(LocalOnly::class);
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,5 +4,5 @@ use Allenjd3\WireLook\Controllers\WireLookController;
 use Allenjd3\WireLook\Middleware\LocalOnly;
 use Illuminate\Support\Facades\Route;
 
-Route::get('/wirelook', WireLookController::class)->middleware(LocalOnly::class);
+Route::get('/wirelook', WireLookController::class)->middleware(LocalOnly::class)->name('wirelook');
 

--- a/src/Controllers/WireLookController.php
+++ b/src/Controllers/WireLookController.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Allenjd3\WireLook\Controllers;
+
+class WireLookController
+{
+    public function __invoke()
+    {
+        return view('wirelook::index');
+    }
+}

--- a/src/Controllers/WireLookController.php
+++ b/src/Controllers/WireLookController.php
@@ -2,10 +2,19 @@
 
 namespace Allenjd3\WireLook\Controllers;
 
+use Allenjd3\WireLook\WireLook;
+use Illuminate\Http\Request;
+
 class WireLookController
 {
-    public function __invoke()
+    public function __invoke(Request $request, WireLook $wireLook)
     {
-        return view('wirelook::index');
+        $previews = $wireLook->loadPreviews();
+        $includes = ['keys' => array_keys($previews)];
+        if ($request->has('component')) {
+            $includes = [...$includes, 'componentName' => ($previews[$request->input('component')])->getComponentName()];
+        }
+
+        return view('wirelook::index', $includes);
     }
 }

--- a/src/Middleware/LocalOnly.php
+++ b/src/Middleware/LocalOnly.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Allenjd3\WireLook\Middleware;
+
+use Closure;
+use Illuminate\Foundation\Application;
+use Illuminate\Http\Request;
+
+class LocalOnly
+{
+    public function __construct(
+        public Application $app,
+    ) {
+    }
+
+    public function handle(Request $request, Closure $next)
+    {
+        if ($this->app->environment('production')) {
+            abort(403, "This action is not allowed in production");
+        }
+
+        return $next($request);
+    }
+}

--- a/src/Middleware/LocalOnly.php
+++ b/src/Middleware/LocalOnly.php
@@ -10,13 +10,12 @@ class LocalOnly
 {
     public function __construct(
         public Application $app,
-    ) {
-    }
+    ) {}
 
     public function handle(Request $request, Closure $next)
     {
         if ($this->app->environment('production')) {
-            abort(403, "This action is not allowed in production");
+            abort(403, 'This action is not allowed in production');
         }
 
         return $next($request);

--- a/src/Preview.php
+++ b/src/Preview.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Allenjd3\WireLook;
+
+use Illuminate\Support\Facades\Blade;
+
+abstract class Preview
+{
+    public function getComponent() {
+        return Blade::render('<livewire:is :component="$componentName" />', ['componentName' => $this->getComponentName()]);
+    }
+
+    public function getComponentName()
+    {
+        return $this->componentName;
+    }
+}

--- a/src/Preview.php
+++ b/src/Preview.php
@@ -6,11 +6,13 @@ use Illuminate\Support\Facades\Blade;
 
 abstract class Preview
 {
-    public function getComponent() {
+    public function getComponent()
+    {
         return Blade::render('<livewire:is :component="$componentName" />', ['componentName' => $this->getComponentName()]);
     }
 
-    public function getSlug() {
+    public function getSlug()
+    {
         $rules = <<<'RULES'
             :: Any-Latin;
             :: NFD;
@@ -24,7 +26,7 @@ abstract class Preview
         RULES;
 
         return \Transliterator::createFromRules($rules)
-            ->transliterate( $this->getComponentName() );;
+            ->transliterate($this->getComponentName());
     }
 
     public function getComponentName()

--- a/src/Preview.php
+++ b/src/Preview.php
@@ -10,6 +10,23 @@ abstract class Preview
         return Blade::render('<livewire:is :component="$componentName" />', ['componentName' => $this->getComponentName()]);
     }
 
+    public function getSlug() {
+        $rules = <<<'RULES'
+            :: Any-Latin;
+            :: NFD;
+            :: [:Nonspacing Mark:] Remove;
+            :: NFC;
+            :: [^-[:^Punctuation:]] Remove;
+            :: Lower();
+            [:^L:] { [-] > ;
+            [-] } [:^L:] > ;
+            [-[:Separator:]]+ > '-';
+        RULES;
+
+        return \Transliterator::createFromRules($rules)
+            ->transliterate( $this->getComponentName() );;
+    }
+
     public function getComponentName()
     {
         return $this->componentName;

--- a/src/WireLook.php
+++ b/src/WireLook.php
@@ -2,4 +2,23 @@
 
 namespace Allenjd3\WireLook;
 
-class WireLook {}
+use Allenjd3\WireLook\Tests\stubs\TestPreview;
+
+class WireLook {
+    public function loadPreviews(): array
+    {
+        $previews = [];
+
+        foreach (glob(config('wirelook.preview_path') . "*.php") as $filename) {
+            $matches = [];
+            preg_match('/[a-zA-Z0-9_-]+(?=\.php)/', $filename, $matches);
+            $cleanedFileName = $matches[0];
+
+            $preview = config('wirelook.preview_namespace') . $cleanedFileName;
+
+            array_push($previews, new $preview);
+        }
+
+        return $previews;
+    }
+}

--- a/src/WireLook.php
+++ b/src/WireLook.php
@@ -2,17 +2,18 @@
 
 namespace Allenjd3\WireLook;
 
-class WireLook {
+class WireLook
+{
     public function loadPreviews(): array
     {
         $previews = [];
 
-        foreach (glob(config('wirelook.preview_path') . "*.php") as $filename) {
+        foreach (glob(config('wirelook.preview_path').'*.php') as $filename) {
             $matches = [];
             preg_match('/[a-zA-Z0-9_-]+(?=\.php)/', $filename, $matches);
             $cleanedFileName = $matches[0];
 
-            $preview = config('wirelook.preview_namespace') . $cleanedFileName;
+            $preview = config('wirelook.preview_namespace').$cleanedFileName;
 
             $previewInstance = new $preview;
             $previews[$previewInstance->getSlug()] = $previewInstance;

--- a/src/WireLook.php
+++ b/src/WireLook.php
@@ -14,7 +14,8 @@ class WireLook {
 
             $preview = config('wirelook.preview_namespace') . $cleanedFileName;
 
-            array_push($previews, new $preview);
+            $previewInstance = new $preview;
+            $previews[$previewInstance->getSlug()] = $previewInstance;
         }
 
         return $previews;

--- a/src/WireLook.php
+++ b/src/WireLook.php
@@ -2,8 +2,6 @@
 
 namespace Allenjd3\WireLook;
 
-use Allenjd3\WireLook\Tests\stubs\TestPreview;
-
 class WireLook {
     public function loadPreviews(): array
     {

--- a/src/WireLookServiceProvider.php
+++ b/src/WireLookServiceProvider.php
@@ -10,14 +10,10 @@ class WireLookServiceProvider extends PackageServiceProvider
 {
     public function configurePackage(Package $package): void
     {
-        /*
-         * This class is a Package Service Provider
-         *
-         * More info: https://github.com/spatie/laravel-package-tools
-         */
         $package
             ->name('wirelook')
             ->hasConfigFile()
+            ->hasRoute('web')
             ->hasViews()
             ->hasMigration('create_wirelook_table')
             ->hasCommand(WireLookCommand::class);

--- a/src/WireLookServiceProvider.php
+++ b/src/WireLookServiceProvider.php
@@ -2,11 +2,11 @@
 
 namespace Allenjd3\WireLook;
 
-use Spatie\LaravelPackageTools\Package;
-use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Allenjd3\WireLook\Commands\WireLookCommand;
 use Allenjd3\WireLook\Tests\Components\BaseComponent;
 use Livewire\Livewire;
+use Spatie\LaravelPackageTools\Package;
+use Spatie\LaravelPackageTools\PackageServiceProvider;
 
 class WireLookServiceProvider extends PackageServiceProvider
 {

--- a/src/WireLookServiceProvider.php
+++ b/src/WireLookServiceProvider.php
@@ -14,7 +14,7 @@ class WireLookServiceProvider extends PackageServiceProvider
             ->name('wirelook')
             ->hasConfigFile()
             ->hasRoute('web')
-            ->hasViews()
+            ->hasViews('wirelook')
             ->hasMigration('create_wirelook_table')
             ->hasCommand(WireLookCommand::class);
     }

--- a/src/WireLookServiceProvider.php
+++ b/src/WireLookServiceProvider.php
@@ -5,9 +5,20 @@ namespace Allenjd3\WireLook;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Allenjd3\WireLook\Commands\WireLookCommand;
+use Allenjd3\WireLook\Tests\Components\BaseComponent;
+use Livewire\Livewire;
 
 class WireLookServiceProvider extends PackageServiceProvider
 {
+    public function boot()
+    {
+        parent::boot();
+
+        if ($this->app->environment('testing')) {
+            Livewire::component('wirelook::base-component', BaseComponent::class);
+        }
+    }
+
     public function configurePackage(Package $package): void
     {
         $package

--- a/tests/Components/BaseComponent.php
+++ b/tests/Components/BaseComponent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Allenjd3\WireLook\Tests\Components;
+
+use Livewire\Component;
+
+class BaseComponent extends Component
+{
+    public function render()
+    {
+        return view('wirelook::livewire.base');
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,10 +2,10 @@
 
 namespace Allenjd3\WireLook\Tests;
 
-use Illuminate\Database\Eloquent\Factories\Factory;
-use Orchestra\Testbench\TestCase as Orchestra;
-use Livewire\LivewireServiceProvider;
 use Allenjd3\WireLook\WireLookServiceProvider;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Livewire\LivewireServiceProvider;
+use Orchestra\Testbench\TestCase as Orchestra;
 
 class TestCase extends Orchestra
 {
@@ -29,8 +29,8 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
-        config()->set('wirelook.preview_path', __DIR__ . "/stubs/");
-        config()->set('wirelook.preview_namespace', "Allenjd3\\WireLook\\Tests\\stubs\\");
+        config()->set('wirelook.preview_path', __DIR__.'/stubs/');
+        config()->set('wirelook.preview_namespace', 'Allenjd3\\WireLook\\Tests\\stubs\\');
         config()->set('app.key', 'base64:yIAtua5VFaccXs9mbjgjkcxO+UXqPO2IInOxj2nGl9U=');
 
         /*

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -4,6 +4,7 @@ namespace Allenjd3\WireLook\Tests;
 
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Orchestra\Testbench\TestCase as Orchestra;
+use Livewire\LivewireServiceProvider;
 use Allenjd3\WireLook\WireLookServiceProvider;
 
 class TestCase extends Orchestra
@@ -20,6 +21,7 @@ class TestCase extends Orchestra
     protected function getPackageProviders($app)
     {
         return [
+            LivewireServiceProvider::class,
             WireLookServiceProvider::class,
         ];
     }
@@ -27,6 +29,7 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
+        config()->set('app.key', 'base64:yIAtua5VFaccXs9mbjgjkcxO+UXqPO2IInOxj2nGl9U=');
 
         /*
         $migration = include __DIR__.'/../database/migrations/create_wirelook_table.php.stub';

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -29,6 +29,8 @@ class TestCase extends Orchestra
     public function getEnvironmentSetUp($app)
     {
         config()->set('database.default', 'testing');
+        config()->set('wirelook.preview_path', __DIR__ . "/stubs/");
+        config()->set('wirelook.preview_namespace', "Allenjd3\\WireLook\\Tests\\stubs\\");
         config()->set('app.key', 'base64:yIAtua5VFaccXs9mbjgjkcxO+UXqPO2IInOxj2nGl9U=');
 
         /*

--- a/tests/src/Controllers/WirelookControllerTest.php
+++ b/tests/src/Controllers/WirelookControllerTest.php
@@ -13,8 +13,20 @@ it('aborts if app is in production', function () {
 });
 
 it('shows the component', function () {
+    $response = $this->get('wirelook?component=wirelookbase-component');
+    $matches = [];
+    preg_match('/wirelook\:\:base\-component/', $response->getContent(), $matches);
+    $this->assertCount(1, $matches);
+});
+
+it('does not show the component if there is no slug', function () {
+    $response = $this->get('wirelook');
+    $matches = [];
+    preg_match('/wirelook\:\:base\-component/', $response->getContent(), $matches);
+    $this->assertCount(0, $matches);
+});
+
+it('links the previews', function () {
     $this->get('wirelook')
-        ->assertOk();
-        //->dump();
-        //->assertSee('Hello');
+        ->assertSee('wirelookbase-component');
 });

--- a/tests/src/Controllers/WirelookControllerTest.php
+++ b/tests/src/Controllers/WirelookControllerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-it('it can show the component', function () {
+it('can show the component', function () {
     $this->get('/wirelook')
         ->assertOk();
 });
@@ -10,4 +10,11 @@ it('aborts if app is in production', function () {
 
     $this->get('/wirelook')
         ->assertForbidden();
+});
+
+it('shows the component', function () {
+    $this->get('wirelook')
+        ->assertOk();
+        //->dump();
+        //->assertSee('Hello');
 });

--- a/tests/src/Controllers/WirelookControllerTest.php
+++ b/tests/src/Controllers/WirelookControllerTest.php
@@ -1,0 +1,13 @@
+<?php
+
+it('it can show the component', function () {
+    $this->get('/wirelook')
+        ->assertOk();
+});
+
+it('aborts if app is in production', function () {
+    $this->app['env'] = 'production';
+
+    $this->get('/wirelook')
+        ->assertForbidden();
+});

--- a/tests/src/WireLookTest.php
+++ b/tests/src/WireLookTest.php
@@ -8,3 +8,9 @@ it('can load previews', function () {
     $previews = $wireLook->loadPreviews();
     expect($previews[0])->toBeInstanceOf(TestPreview::class);
 });
+
+it('can load component information', function () {
+    $wireLook = new WireLook;
+    $previews = $wireLook->loadPreviews();
+    $this->assertMatchesRegularExpression('/wire\:id/', $previews[0]->getComponent());
+});

--- a/tests/src/WireLookTest.php
+++ b/tests/src/WireLookTest.php
@@ -6,11 +6,11 @@ use Allenjd3\WireLook\WireLook;
 it('can load previews', function () {
     $wireLook = new WireLook;
     $previews = $wireLook->loadPreviews();
-    expect($previews[0])->toBeInstanceOf(TestPreview::class);
+    expect(array_shift($previews))->toBeInstanceOf(TestPreview::class);
 });
 
 it('can load component information', function () {
     $wireLook = new WireLook;
     $previews = $wireLook->loadPreviews();
-    $this->assertMatchesRegularExpression('/wire\:id/', $previews[0]->getComponent());
+    $this->assertMatchesRegularExpression('/wire\:id/', (array_shift($previews))->getComponent());
 });

--- a/tests/src/WireLookTest.php
+++ b/tests/src/WireLookTest.php
@@ -1,0 +1,10 @@
+<?php
+
+use Allenjd3\WireLook\Tests\stubs\TestPreview;
+use Allenjd3\WireLook\WireLook;
+
+it('can load previews', function () {
+    $wireLook = new WireLook;
+    $previews = $wireLook->loadPreviews();
+    expect($previews[0])->toBeInstanceOf(TestPreview::class);
+});

--- a/tests/stubs/TestPreview.php
+++ b/tests/stubs/TestPreview.php
@@ -2,7 +2,9 @@
 
 namespace Allenjd3\WireLook\Tests\stubs;
 
-class TestPreview
-{
+use Allenjd3\WireLook\Preview;
 
+class TestPreview extends Preview
+{
+    protected $componentName = 'wirelook::base-component';
 }

--- a/tests/stubs/TestPreview.php
+++ b/tests/stubs/TestPreview.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Allenjd3\WireLook\Tests\stubs;
+
+class TestPreview
+{
+
+}


### PR DESCRIPTION
This allows the autoloading of Previews from the App\Previews directory and the base display of them on the /wirelook path.

- **Add new wirelook route local route**
- **Adds a hello world route**
- **Add livewire and allow dynamic component reg**
- **Allow loading of previews**
- **Add abstract preview class**
- **Build base version of component viewer**
- **Fix composer.json syntax error.**
- **Fix composer.json formatting**
- **Fix references**
